### PR TITLE
Ignore nil nodes in hickory-to-html

### DIFF
--- a/src/hickory/core.clj
+++ b/src/hickory/core.clj
@@ -123,29 +123,30 @@
    as we do not keep any letter case or whitespace information, any
    \"tag-soupy\" elements, attribute quote characters used, etc."
   [dom]
-  (if (string? dom)
-    (qt/html-escape dom)
-    (case (:type dom)
-      :document
-      (apply str (map hickory-to-html (:content dom)))
-      :document-type
-      (str "<!DOCTYPE " (get-in dom [:attrs :name])
-           (when-let [publicid (not-empty (get-in dom [:attrs :publicid]))]
-             (str " PUBLIC \"" publicid "\""))
-           (when-let [systemid (not-empty (get-in dom [:attrs :systemid]))]
-             (str " \"" systemid "\""))
-           ">")
-      :element
-      (if (void-element (:tag dom))
-        (str "<" (name (:tag dom))
-             (apply str (map #(str " " (name (key %)) "=\"" (val %) "\"")
-                             (:attrs dom)))
-             ">")
-        (str "<" (name (:tag dom))
-             (apply str (map #(str " " (name (key %)) "=\"" (val %) "\"")
-                             (:attrs dom)))
-             ">"
-             (apply str (map hickory-to-html (:content dom)))
-             "</" (name (:tag dom)) ">"))
-      :comment
-      (str "<!--" (apply str (:content dom)) "-->"))))
+  (cond
+   (string? dom) (qt/html-escape dom)
+   (nil? dom) nil
+   :else (case (:type dom)
+           :document
+           (apply str (map hickory-to-html (:content dom)))
+           :document-type
+           (str "<!DOCTYPE " (get-in dom [:attrs :name])
+                (when-let [publicid (not-empty (get-in dom [:attrs :publicid]))]
+                  (str " PUBLIC \"" publicid "\""))
+                (when-let [systemid (not-empty (get-in dom [:attrs :systemid]))]
+                  (str " \"" systemid "\""))
+                ">")
+           :element
+           (if (void-element (:tag dom))
+             (str "<" (name (:tag dom))
+                  (apply str (map #(str " " (name (key %)) "=\"" (val %) "\"")
+                                  (:attrs dom)))
+                  ">")
+             (str "<" (name (:tag dom))
+                  (apply str (map #(str " " (name (key %)) "=\"" (val %) "\"")
+                                  (:attrs dom)))
+                  ">"
+                  (apply str (map hickory-to-html (:content dom)))
+                  "</" (name (:tag dom)) ">"))
+           :comment
+           (str "<!--" (apply str (:content dom)) "-->"))))


### PR DESCRIPTION
This is a small change to make it so that hickory-to-html doesn't fail on `nil`. Lots of Clojure functions tend to return nil in various scenarios, and I think it makes sense to handle `nil`s rather than throw an exception on them. It's also useful to me because it makes it easy to 'remove' nodes in a hickory zipper without using `zip/remove` and instead replacing them with `nil`, since I'm doing a postorder walk and `zip/remove` jumps to the next node in a depth-first walk.

Does this make sense?
