### PR TITLE
Added some error handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "http://github.com/davidsantiago/hickory"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [quoin "0.1.0"]
                  [org.jsoup/jsoup "1.7.1"]])

--- a/src/hickory/core.clj
+++ b/src/hickory/core.clj
@@ -133,33 +133,39 @@
   [dom]
   (if (string? dom)
     (qt/html-escape dom)
-    (case (:type dom)
-      :document
-      (apply str (map hickory-to-html (:content dom)))
-      :document-type
-      (str "<!DOCTYPE " (get-in dom [:attrs :name])
-           (when-let [publicid (not-empty (get-in dom [:attrs :publicid]))]
-             (str " PUBLIC \"" publicid "\""))
-           (when-let [systemid (not-empty (get-in dom [:attrs :systemid]))]
-             (str " \"" systemid "\""))
-           ">")
-      :element
-      (cond
-       (void-element (:tag dom))
-       (str "<" (name (:tag dom))
-            (apply str (map render-attribute (:attrs dom)))
-            ">")
-       (unescapable-content (:tag dom))
-       (str "<" (name (:tag dom))
-            (apply str (map render-attribute (:attrs dom)))
-            ">"
-            (apply str (:content dom)) ;; Won't get html-escaped.
-            "</" (name (:tag dom)) ">")
-       :else
-       (str "<" (name (:tag dom))
-            (apply str (map render-attribute (:attrs dom)))
-            ">"
-            (apply str (map hickory-to-html (:content dom)))
-            "</" (name (:tag dom)) ">"))
-      :comment
-      (str "<!--" (apply str (:content dom)) "-->"))))
+    (try
+      (case (:type dom)
+        :document
+        (apply str (map hickory-to-html (:content dom)))
+        :document-type
+        (str "<!DOCTYPE " (get-in dom [:attrs :name])
+             (when-let [publicid (not-empty (get-in dom [:attrs :publicid]))]
+               (str " PUBLIC \"" publicid "\""))
+             (when-let [systemid (not-empty (get-in dom [:attrs :systemid]))]
+               (str " \"" systemid "\""))
+             ">")
+        :element
+        (cond
+         (void-element (:tag dom))
+         (str "<" (name (:tag dom))
+              (apply str (map render-attribute (:attrs dom)))
+              ">")
+         (unescapable-content (:tag dom))
+         (str "<" (name (:tag dom))
+              (apply str (map render-attribute (:attrs dom)))
+              ">"
+              (apply str (:content dom)) ;; Won't get html-escaped.
+              "</" (name (:tag dom)) ">")
+         :else
+         (str "<" (name (:tag dom))
+              (apply str (map render-attribute (:attrs dom)))
+              ">"
+              (apply str (map hickory-to-html (:content dom)))
+              "</" (name (:tag dom)) ">"))
+        :comment
+        (str "<!--" (apply str (:content dom)) "-->"))
+      (catch IllegalArgumentException e
+        (throw
+         (if (.startsWith (.getMessage e) "No matching clause: ")
+           (ex-info (str "Not a valid node: " (pr-str dom)) {:dom dom})
+           e))))))

--- a/test/hickory/test/core.clj
+++ b/test/hickory/test/core.clj
@@ -100,3 +100,13 @@
          (hickory-to-html (as-hickory (parse "<!DOCTYPE html><html><head></head><body></body></html>")))))
   (is (= "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><html><head></head><body></body></html>"
          (hickory-to-html (as-hickory (parse "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><html><head></head><body></body</html>"))))))
+
+(deftest error-handling
+  (let [data {:type :foo :tag :a :attrs {:foo "bar"}}]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"^Not a valid node: nil"
+          (hickory-to-html nil)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"^Not a valid node: \{:type :foo, :attrs \{:foo \"bar\"\}, :tag :a\}"
+          (hickory-to-html data)))
+    (is (= data 
+           (try (hickory-to-html data)
+                (catch Exception e (:dom (ex-data e))))))))


### PR DESCRIPTION
This is the first thing I came up with. I've been using it locally for a while and it works well for me.

In summary, it catches the blank "No matching clause: " exception and throws an ex-info exception that contains the 'dom'. The message of this exception is "Not a valid node: <insert whatever dom is here>". The only part I'm not really sure about is how I remove the `:content` key from the `dom` arg if it is a map. If `dom` is a map and that no matching clause exception occurred, it's going to be because the `:type` key was missing or incorrect. In those cases, it'd try to print the whole map which would be that part of the tree all the way down, which could potentially mean printing a huuuuuuge piece of HTML in an error message. Not sure if you care about that, but it seemed like the right thing to do.

If this isn't what you're looking for at all, that's fine too! If that's the case, I can revamp it with any ideas you might have.
