### PR TITLE
Hiccup zipper cleanup.

### DIFF
--- a/src/hickory/zip.clj
+++ b/src/hickory/zip.clj
@@ -19,41 +19,12 @@
 ;; Hiccup
 ;;
 
-;; Just to make things easier, we go ahead and do the work here to
-;; make hiccup zippers work on both normalized (all items have tag,
-;; attrs map, and any children) and unnormalized hiccup forms.
-
-(defn- children
-  "Takes a hiccup node (normalized or not) and returns its children nodes."
-  [node]
-  (if (vector? node)
-    ;; It's a hiccup node vector.
-    (if (map? (second node)) ;; There is an attr map in second slot.
-      (seq (subvec node 2))  ;; So skip tag and attr vec.
-      (seq (subvec node 1))) ;; Otherwise, just skip tag.
-    ;; Otherwise, must have a been a node list
-    node))
-
-;; Note, it's not made clear at all in the docs for clojure.zip, but as far as
-;; I can tell, you are given a node potentially with existing children and
-;; the sequence of children that should totally replace the existing children.
-(defn- make
-  "Takes a hiccup node (normalized or not) and a sequence of children nodes,
-   and returns a new node that has the the children argument as its children."
-  [node children]
-  ;; The node might be either a vector (hiccup form) or a seq (which is like a
-  ;; node-list).
-  (if (vector? node)
-    (if (map? (second node))                 ;; Again, check for normalized vec.
-      (into (subvec node 0 2) children)      ;; Attach children after tag&attrs.
-      (apply vector (first node) children))  ;; Otherwise, attach after tag.
-    children))   ;; We were given a list for node, so just return the new list.
-
-
 (defn hiccup-zip
   "Returns a zipper for Hiccup forms, given a root form."
   [root]
-  (zip/zipper sequential?
-              children
-              make
-              root))
+  (let [children-pos #(if (map? (second %)) 2 1)]
+    (zip/zipper
+      vector?
+      #(drop (children-pos %) %) ; get children
+      #(into [] (concat (take (children-pos %1) %1) %2)) ; make new node
+      root)))

--- a/test/hickory/test/zip.clj
+++ b/test/hickory/test/zip.clj
@@ -66,17 +66,24 @@
              zip/next zip/next zip/next zip/up zip/node))))
 
 (deftest hiccup-zipper
-  (is (= '([:html {} [:head {}] [:body {} [:a {}]]])
-         (zip/node (hiccup-zip (as-hiccup (parse "<a>"))))))
-  (is (= [:html {} [:head {}] [:body {} [:a {}]]]
-         (-> (hiccup-zip (as-hiccup (parse "<a>")))
+  (let [single-elem (hiccup-zip (first (as-hiccup (parse "<a>"))))]
+    (is (= [:html {} [:head {}] [:body {} [:a {}]]]
+           (zip/root single-elem)))
+    (is (= [:head {}]
+           (-> single-elem
              zip/next zip/node)))
-  (is (= [:head {}]
-         (-> (hiccup-zip (as-hiccup (parse "<a>")))
+    (is (nil?
+           (-> single-elem ; no children - empty collection
              zip/next zip/next zip/node)))
-  (is (= [:body {} [:a {}]]
-         (-> (hiccup-zip (as-hiccup (parse "<a>")))
+    (is (= [:body {} [:a {}]]
+           (-> single-elem
+             zip/down zip/right zip/node)))
+    (is (= [:body {} [:a {}]]
+           (-> single-elem
              zip/next zip/next zip/next zip/node)))
-  (is (= [:html {} [:head {}] [:body {} [:a {}]]]
-         (-> (hiccup-zip (as-hiccup (parse "<a>")))
-             zip/next zip/next zip/next zip/up zip/node))))
+    (is (= [:html {} [:head {}] [:body {} [:a {}]]]
+           (-> single-elem
+             zip/next zip/next zip/next zip/up zip/node)))
+    (is (= [:html {} [:head {}] [:body {:onload "alert()"} [:a {}]]]
+           (-> single-elem
+             zip/down zip/right (zip/edit #(assoc-in % [1 :onload] "alert()")) zip/root)))))


### PR DESCRIPTION
Here is more compact implementation of hiccup zipper.
Traversal order has changed: now zipper will visit empty children collection if node can possibly have children. I believe this is correct behavior.
