### PR TITLE
Do not define invalid typehints for ClojureScript

### DIFF
--- a/src/hickory/hiccup_utils.cljx
+++ b/src/hickory/hiccup_utils.cljx
@@ -11,7 +11,8 @@
              (first-idx -1 2) => 2
              (first-idx 5 -1) => 5
              (first-idx 5 3) => 3"
-  [^long a ^long b]
+  [#+clj ^long a #+clj ^long b
+   #+cljs a #+cljs b]
   (if (== a -1)
     b
     (if (== b -1)


### PR DESCRIPTION
ClojureScript now recognize typehints and will issue some warnings when encountering invalid ones.

```
WARNING: cljs.core/==, all arguments must be numbers, got [long number] instead. at line 15 /Users/julien/Documents/Projects/refugio-ui/target/cljsbuild-compiler-1/hickory/hiccup_utils.cljs
...
```

I removed `^long` typehints from ClojureScript codebase as they are irrelevant in JavaScript.
