### PR TITLE
Wrap ClojureScript dependencies/plugins in dev profile.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,14 @@
   :source-paths ["src"  "target/generated-src"]
   :test-paths ["target/generated-test"]
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1934"]
                  [quoin "0.1.0"]
                  [org.jsoup/jsoup "1.7.1"]]
-  :plugins [[codox "0.6.4"]
-            [lein-cljsbuild "0.3.4"]
-            [com.keminglabs/cljx "0.3.0"]
-            [com.cemerick/clojurescript.test "0.1.0"]]
+  :plugins [[codox "0.6.4"]]
+  :profiles {:dev
+             {:dependencies [[org.clojure/clojurescript "0.0-2227"]]
+              :plugins [[lein-cljsbuild "1.0.3"]
+                        [com.keminglabs/cljx "0.4.0"]
+                        [com.cemerick/clojurescript.test "0.3.1"]]}}
   :hooks [cljx.hooks]
   :codox {:sources ["src" "target/generated-src"]
           :output-dir "codox-out"


### PR DESCRIPTION
This ensures ClojureScript dependencies do not leak to project using hickory, reducing potential version conflicts and preventing them to end up in uberjar packages.

ClojureScript, cljx and clojurescript.test have been upgraded to latest available releases.
