### PR TITLE
Class names can be separated by any whitespace characters

### DIFF
--- a/src/cljc/hickory/select.cljc
+++ b/src/cljc/hickory/select.cljc
@@ -246,7 +246,7 @@
   [class-name]
   (letfn [(parse-classes [class-str]
                        (into #{} (mapv string/lower-case
-                                       (string/split class-str #" "))))]
+                                       (string/split class-str #"\s+"))))]
     (attr :class #(contains? (parse-classes %)
                              (string/lower-case (name class-name))))))
 

--- a/test/cljc/hickory/test/select.cljc
+++ b/test/cljc/hickory/test/select.cljc
@@ -22,7 +22,8 @@
 <div class=\"subdiv cool\" id=\"deepestdiv\">Div</div>
 </span>
 <!-- Comment 2 -->
-<span id=\"anid\" class=\"cool\">Span</span>
+<span id=\"anid\" class=\"line-feed-ahead
+cool\">Span</span>
 </div>
 </body>
 </html>")
@@ -196,6 +197,12 @@
                                      htree)]
         (is (and (= 1 (count selection))
                  (re-find #"aclass"
+                          (-> selection first :attrs :class)))))
+      ;; class followed by line feed
+      (let [selection (select/select (select/class :line-feed-ahead)
+                                     htree)]
+        (is (and (= 1 (count selection))
+                 (re-find #"line-feed-ahead"
                           (-> selection first :attrs :class))))))))
 
 (deftest any-test


### PR DESCRIPTION
Class names can be separated by any whitespace according to [DOM standard](https://dom.spec.whatwg.org/#concept-class)

I came across line feed following a class in [this page](https://www.booking.com/searchresults.en-us.html?label=gen173nr-1DCAEoggI46AdIM1gEaFCIAQGYATG4AQfIAQzYAQPoAQH4AQKIAgGoAgO4ApXIw-sFwAIB&sid=e0eddec745517c5943b68c9173ce7e52&sb=1&src=index&src_elem=sb&error_url=https%3A%2F%2Fwww.booking.com%2Findex.html%3Flabel%3Dgen173nr-1DCAEoggI46AdIM1gEaFCIAQGYATG4AQfIAQzYAQPoAQH4AQKIAgGoAgO4ApXIw-sFwAIB%3Bsid%3De0eddec745517c5943b68c9173ce7e52%3Bsb_price_type%3Dtotal%26%3B&ss=London%2C+Greater+London%2C+United+Kingdom&is_ski_area=0&checkin_month=&checkin_monthday=&checkin_year=&checkout_month=&checkout_monthday=&checkout_year=&group_adults=2&group_children=0&no_rooms=1&b_h4u_keep_filters=&from_sf=1&ss_raw=london&ac_position=0&ac_langcode=en&ac_click_type=b&dest_id=-2601889&dest_type=city&iata=LON&place_id_lat=51.507391&place_id_lon=-0.127634&search_pageview_id=42244a0a9b0f0048&search_selected=true):
```
class="sr-hotel__name
"
```
