### PR TITLE
Make Hickory usable again by upgrading dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
 
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.293"]
-                 [org.jsoup/jsoup "1.9.2"]
-                 [viebel/codox-klipse-theme "0.0.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/clojurescript "1.11.60"]
+                 [org.jsoup/jsoup "1.15.2"]
+                 [viebel/codox-klipse-theme "0.0.5"]
                  [quoin "0.1.2" :exclusions [org.clojure/clojure]]]
 
   :hooks [leiningen.cljsbuild]
@@ -23,7 +23,7 @@
 
   :profiles
   {:dev  {:source-paths ["src/clj" "src/cljc"]
-          :dependencies [[lein-doo "0.1.7"]]
+          :dependencies [[lein-doo "0.1.11"]]
           :plugins      [[lein-cljsbuild "1.1.4"]
                          [lein-doo "0.1.7" :exclusions [org.clojure/clojure]]]}
    :test {:source-paths ["src/cljs" "src/cljc" "test/cljc" "test/cljs"]


### PR DESCRIPTION
Hickory has multiple issues due to outdated dependencies, which render it unusable with current versions of Clojure, Java, etc.

- The version of jsoup it depends on has CVEs (#62).
- The version of ClojureScript it depends on has [a broken `ns` form](https://github.com/clojure/clojurescript/commit/48b83d900dc46e912fcefc2365f806f5c8c15dfe).  This seems to have been tolerated with older Clojure versions, but as of 1.11.x, it causes a build failure.
- One of its dependencies (I’m not sure which) breaks with Java > 8 due to the unbundling of JAX-WS.