### PR TITLE
Minor cleanups.

### DIFF
--- a/src/clj/hickory/core.clj
+++ b/src/clj/hickory/core.clj
@@ -4,7 +4,7 @@
             [clojure.zip :as zip])
   (:import [org.jsoup Jsoup]
            [org.jsoup.nodes Attribute Attributes Comment DataNode Document
-            DocumentType Element Node TextNode XmlDeclaration]
+            DocumentType Element TextNode XmlDeclaration]
            [org.jsoup.parser Tag Parser]))
 
 (defn- end-or-recur [as-fn loc data & [skip-child?]]

--- a/src/cljc/hickory/convert.cljc
+++ b/src/cljc/hickory/convert.cljc
@@ -32,25 +32,24 @@
   [dom]
   (if (string? dom)
     (utils/html-escape dom)
-    (try
-      (case (:type dom)
-        :document
-        (mapv hickory-to-hiccup (:content dom))
-        :document-type
-        (utils/render-doctype (get-in dom [:attrs :name])
-                              (get-in dom [:attrs :publicid])
-                              (get-in dom [:attrs :systemid]))
-        :element
-        (if (utils/unescapable-content (:tag dom))
-          (if (every? string? (:content dom))
-            ;; Merge :attrs contents with {} to prevent nil from getting into
-            ;; the hiccup forms when there are no attributes.
-            (apply vector (:tag dom) (into {} (:attrs dom)) (:content dom))
-            (throw (ex-info
-                    "An unescapable content tag had non-string children."
-                    {:error-location dom})))
-          (apply vector (:tag dom) (into {} (:attrs dom))
-                 (map hickory-to-hiccup (:content dom))))
-        :comment
-        (str "<!--" (apply str (:content dom)) "-->")))))
+    (case (:type dom)
+      :document
+      (mapv hickory-to-hiccup (:content dom))
+      :document-type
+      (utils/render-doctype (get-in dom [:attrs :name])
+                            (get-in dom [:attrs :publicid])
+                            (get-in dom [:attrs :systemid]))
+      :element
+      (if (utils/unescapable-content (:tag dom))
+        (if (every? string? (:content dom))
+          ;; Merge :attrs contents with {} to prevent nil from getting into
+          ;; the hiccup forms when there are no attributes.
+          (apply vector (:tag dom) (into {} (:attrs dom)) (:content dom))
+          (throw (ex-info
+                  "An unescapable content tag had non-string children."
+                  {:error-location dom})))
+        (apply vector (:tag dom) (into {} (:attrs dom))
+               (map hickory-to-hiccup (:content dom))))
+      :comment
+      (str "<!--" (apply str (:content dom)) "-->"))))
 

--- a/test/cljc/hickory/test/select.cljc
+++ b/test/cljc/hickory/test/select.cljc
@@ -399,7 +399,8 @@
                                                 (select/class "notpresent")
                                                 (select/id :nothere))
                                      htree)]
-        (= [] selection))
+        (is (and (= 1 (count selection))
+                 (every? true? (map #(= :a (:tag %)) selection)))))
       (let [selection (select/select (select/or (select/tag :div))
                                      htree)]
         (is (and (= 2 (count selection))


### PR DESCRIPTION
- Remove unused jsoup `Node` import in core.clj.
- Remove `try` form with no catch or finally clause from `hickory-to-hiccup`.
- Fix first test of `or-test`, which had no asserts.