### PR TITLE
Generate deps.edn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml
 .lein-plugins
 .lein-repl-history
 out/
+.cpcache

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,5 @@
+{:deps {io.github.borkdude/lein2deps {:git/url "https://github.com/borkdude/lein2deps"
+                                      :git/sha "e26edeb114c9d88a5c4d3abb683306588fcaad13"}}
+ :tasks {lein2deps {:doc "Generate deps.edn from project.clj"
+                    :requires ([lein2deps.api :as lein2deps])
+                    :task (lein2deps/lein2deps {:write-file "deps.edn"})}} }

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src/clj" "src/cljc" "src/cljs"],
+ :deps
+ {org.clojure/clojure {:mvn/version "1.8.0"},
+  org.clojure/clojurescript {:mvn/version "1.9.293"},
+  org.jsoup/jsoup {:mvn/version "1.14.3"},
+  viebel/codox-klipse-theme {:mvn/version "0.0.1"},
+  quoin/quoin
+  {:mvn/version "0.1.2", :exclusions [org.clojure/clojure]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,11 @@
 {:paths ["src/clj" "src/cljc" "src/cljs"],
  :deps
  {org.clojure/clojure {:mvn/version "1.8.0"},
-  org.clojure/clojurescript {:mvn/version "1.9.293"},
   org.jsoup/jsoup {:mvn/version "1.14.3"},
-  viebel/codox-klipse-theme {:mvn/version "0.0.1"},
   quoin/quoin
-  {:mvn/version "0.1.2", :exclusions [org.clojure/clojure]}}}
+  {:mvn/version "0.1.2", :exclusions [org.clojure/clojure]}},
+ :aliases
+ {:dev
+  {:extra-deps
+   {org.clojure/clojurescript {:mvn/version "1.9.293"},
+    viebel/codox-klipse-theme {:mvn/version "0.0.1"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,10 @@
 
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.293"]
                  [org.jsoup/jsoup "1.14.3"]
-                 [viebel/codox-klipse-theme "0.0.1"]
-                 [quoin "0.1.2" :exclusions [org.clojure/clojure]]]
+                 [quoin "0.1.2" :exclusions [org.clojure/clojure]]
+                 [org.clojure/clojurescript "1.9.293" :scope "provided"]
+                 [viebel/codox-klipse-theme "0.0.1" :scope "provided"]]
 
   :hooks [leiningen.cljsbuild]
 


### PR DESCRIPTION
This adds a generated deps.edn so you can start using this library as a git dep.