### PR TITLE
feat: integrate html-escape function to get rid of needless dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,7 @@
 {:paths ["src/clj" "src/cljc" "src/cljs"],
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
-  org.jsoup/jsoup {:mvn/version "1.15.2"},
-  quoin/quoin
-  {:mvn/version "0.1.2", :exclusions [org.clojure/clojure]}},
+  org.jsoup/jsoup {:mvn/version "1.15.2"}},
  :aliases
  {:test {:extra-paths ["test/cljc"]}
   :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}}}

--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,7 @@
 
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/clojurescript "1.11.60" :scope "provided"]
-                 [org.jsoup/jsoup "1.15.2"]
-                 [quoin "0.1.2" :exclusions [org.clojure/clojure]]]
+                 [org.jsoup/jsoup "1.15.2"]]
 
   :source-paths ["src/clj" "src/cljc" "src/cljs"]
 

--- a/src/cljc/hickory/utils.cljc
+++ b/src/cljc/hickory/utils.cljc
@@ -1,9 +1,7 @@
 (ns hickory.utils
   "Miscellaneous utilities used internally."
   (:require [clojure.string :as string]
-    #?(:clj
-            [quoin.text :as qt]
-       :cljs [goog.string :as gstring])))
+            #?(:cljs [goog.string :as gstring])))
 
 ;;
 ;; Data
@@ -22,9 +20,27 @@
 ;; String utils
 ;;
 
+(defn clj-html-escape-without-quoin
+  "Actually copy pasted from quoin: https://github.com/davidsantiago/quoin/blob/develop/src/quoin/text.clj"
+  [^String s]
+  ;; This method is "Java in Clojure" for serious speedups.
+  (let [sb (StringBuilder.)
+        slength (long (count s))]
+    (loop [idx (long 0)]
+      (if (>= idx slength)
+        (.toString sb)
+        (let [c (char (.charAt s idx))]
+          (case c
+            \& (.append sb "&amp;")
+            \< (.append sb "&lt;")
+            \> (.append sb "&gt;")
+            \" (.append sb "&quot;")
+            (.append sb c))
+          (recur (inc idx)))))))
+
 (defn html-escape
   [s]
-  #?(:clj  (qt/html-escape s)
+  #?(:clj  (clj-html-escape-without-quoin s)
      :cljs (gstring/htmlEscape s)))
 
 (defn starts-with


### PR DESCRIPTION
Relying on a nearly 10 year stale dependency for one single utility function seems like a bad idea...
So I copy pasted the imported utility function into our own `utils.cljc`.