### PR TITLE
Put Stringbuilder-based code inside clj block

### DIFF
--- a/src/cljc/hickory/utils.cljc
+++ b/src/cljc/hickory/utils.cljc
@@ -24,19 +24,21 @@
   "Actually copy pasted from quoin: https://github.com/davidsantiago/quoin/blob/develop/src/quoin/text.clj"
   [^String s]
   ;; This method is "Java in Clojure" for serious speedups.
-  (let [sb (StringBuilder.)
-        slength (long (count s))]
-    (loop [idx (long 0)]
-      (if (>= idx slength)
-        (.toString sb)
-        (let [c (char (.charAt s idx))]
-          (case c
-            \& (.append sb "&amp;")
-            \< (.append sb "&lt;")
-            \> (.append sb "&gt;")
-            \" (.append sb "&quot;")
-            (.append sb c))
-          (recur (inc idx)))))))
+  #?(:clj (let [sb (StringBuilder.)
+                slength (long (count s))]
+            (loop [idx (long 0)]
+              (if (>= idx slength)
+                (.toString sb)
+                (let [c (char (.charAt s idx))]
+                  (case c
+                    \& (.append sb "&amp;")
+                    \< (.append sb "&lt;")
+                    \> (.append sb "&gt;")
+                    \" (.append sb "&quot;")
+                    (.append sb c))
+                  (recur (inc idx))))))
+     ;; This shouldn't be called directly in cljs, but if it is, we use the same implementation as the html-escape function
+     :cljs (gstring/htmlEscape s)))
 
 (defn html-escape
   [s]


### PR DESCRIPTION
The hickory cljc file uses Stringbuilder, even though it is java code. The relevant function is only ever called from clj, but its existence in the cljc file causes some cljs compilation warnings.

This PR puts that code inside a clj block, to prevent warnings.

Note the code would be nicer if we removed the `clj-html-escape-without-quoin` function entirely, since it exists only to be called within `html-escape`, which already uses a clj block. However, I didn't want to break the functionality for any users who might be calling `clj-html-escape-without-quoin` directly, for some reason.