### PR TITLE
tests - update namespace to not use reader conditionals for clojure.test

### DIFF
--- a/test/cljc/hickory/test/core.cljc
+++ b/test/cljc/hickory/test/core.cljc
@@ -1,8 +1,6 @@
 (ns hickory.test.core
   (:require [hickory.core :refer [as-hickory as-hiccup parse parse-fragment]]
-    #?(:clj
-            [clojure.test :refer [deftest is]]
-       :cljs [cljs.test :refer-macros [is are deftest testing use-fixtures]])))
+            [clojure.test :refer [deftest is]]))
 
 ;; This document tests: doctypes, white space text nodes, attributes,
 ;; and cdata nodes.

--- a/test/cljc/hickory/test/hiccup_utils.cljc
+++ b/test/cljc/hickory/test/hiccup_utils.cljc
@@ -1,9 +1,7 @@
 (ns hickory.test.hiccup-utils
   (:require [hickory.hiccup-utils :refer [class-names id normalize-form
                                           tag-name tag-well-formed?]]
-    #?(:clj
-            [clojure.test :refer :all]
-       :cljs [cljs.test :refer-macros [is are deftest testing use-fixtures]])))
+            [clojure.test :refer [deftest is]]))
 
 #?(:clj
    (deftest first-idx-test
@@ -94,4 +92,3 @@
   (is (= [:a {:id nil :class nil}
           [:b {:id nil :class nil} "foo" [:i {:id nil :class nil} "bar"]]]
          (normalize-form [:a [:b "foo" [:i "bar"]]]))))
-

--- a/test/cljc/hickory/test/select.cljc
+++ b/test/cljc/hickory/test/select.cljc
@@ -4,8 +4,7 @@
             [hickory.utils :as utils]
             [hickory.zip :as hzip]
             [clojure.zip :as zip]
-    #?(:clj[clojure.test :refer :all]
-       :cljs [cljs.test :refer-macros [is are deftest testing use-fixtures]])))
+            [clojure.test :refer [deftest is testing]]))
 
 (def html1
   "<!DOCTYPE html>

--- a/test/cljc/hickory/test/zip.cljc
+++ b/test/cljc/hickory/test/zip.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.zip :as zip]
             [hickory.core :refer [as-hiccup as-hickory parse]]
             [hickory.zip :refer [hickory-zip hiccup-zip]]
-    #?(:clj[clojure.test :refer :all]
-       :cljs [cljs.test :refer-macros [is are deftest testing use-fixtures]])))
+            [clojure.test :refer [deftest is]]))
 
 (deftest hickory-zipper
   (is (= {:type :document,


### PR DESCRIPTION
clojure.test also works via fallback from clojure.test -> cljs.test.
