### PR TITLE
fix: find-in-text returning a string instead of a zip-loc

### DIFF
--- a/src/cljc/hickory/select.cljc
+++ b/src/cljc/hickory/select.cljc
@@ -288,9 +288,11 @@
    selected."
   [re]
   (fn [hzip-loc]
-    (some #(re-find re %) (->> (zip/node hzip-loc)
-                               :content
-                               (filter string?)))))
+    (when (some #(re-find re %)
+                (->> (zip/node hzip-loc)
+                     :content
+                     (filter string?)))
+      hzip-loc)))
 
 (defn n-moves-until
   "This selector returns a selector function that selects its argument if

--- a/test/cljc/hickory/test/select.cljc
+++ b/test/cljc/hickory/test/select.cljc
@@ -8,40 +8,38 @@
 
 (def html1
   "<!DOCTYPE html>
-<!-- Comment 1 -->
-<html>
-<head></head>
-<body>
-<h1>Heading</h1>
-<p>Paragraph</p>
-<a href=\"http://example.com\">Link</a>
-<div class=\"aclass bclass cool\">
-<span disabled anotherattr=\"\" thirdthing=\"44\" id=\"attrspan\"
-      Capitalized=\"UPPERCASED\">
-<div class=\"subdiv cool\" id=\"deepestdiv\">Div</div>
-</span>
-<!-- Comment 2 -->
-<span id=\"anid\" class=\"line-feed-ahead
-cool\">Span</span>
-</div>
-</body>
-</html>")
+    <!-- Comment 1 -->
+    <html>
+    <head></head>
+    <body>
+        <h1>Heading</h1>
+        <p>Paragraph</p>
+        <a href=\"http://example.com\">Link</a>
+        <div class=\"aclass bclass cool\">
+            <span disabled anotherattr=\"\" thirdthing=\"44\" id=\"attrspan\" Capitalized=\"UPPERCASED\">
+                <div class=\"subdiv cool\" id=\"deepestdiv\">Div</div>
+            </span>
+            <!-- Comment 2 -->
+            <span id=\"anid\" class=\"line-feed-ahead cool\">Span</span>
+        </div>
+    </body>
+    </html>")
 
 (def html2
   "<!DOCTYPE html>
-<html>
-<head></head>
-<body>
-<p>Paragraph 1</p>
-<p>Paragraph 2</p>
-<p>Paragraph 3</p>
-<p>Paragraph 4</p>
-<p>Paragraph 5</p>
-<p>Paragraph 6</p>
-<p>Paragraph 7</p>
-<p>Paragraph 8</p>
-</body>
-</html>")
+    <html>
+    <head></head>
+    <body>
+        <p>Paragraph 1</p>
+        <p>Paragraph 2</p>
+        <p>Paragraph 3</p>
+        <p>Paragraph 4</p>
+        <p>Paragraph 5</p>
+        <p>Paragraph 6</p>
+        <p>Paragraph 7</p>
+        <p>Paragraph 8</p>
+    </body>
+    </html>")
 
 (deftest select-next-loc-test
   (testing "The select-next-loc function."
@@ -232,7 +230,15 @@ cool\">Span</span>
                  (= :h1 (-> selection first :tag)))))
       (let [selection (select/select (select/find-in-text #"Div") htree)]
         (is (and (= 1 (count selection))
-                 (= :div (-> selection first :tag))))))
+                 (= :div (-> selection first :tag)))))
+      (let [selection-locs (select/select-locs
+                            (select/child (select/tag :body)
+                                          (select/find-in-text #"Paragraph"))
+                            htree)
+            selection (mapv zip/node selection-locs)]
+        (is (and (= 1 (count selection))
+                 (= :p (-> selection first :tag))
+                 (= :body (-> selection-locs first zip/up zip/node :tag))))))
     (let [htree (hickory/as-hickory (hickory/parse html2))]
       (let [selection (select/select (select/find-in-text #"Paragraph") htree)]
         (is (and (= 8 (count selection))


### PR DESCRIPTION
# Find in Text Selector Return Value

This pull request aims to fix #83, caused due to the `find-in-text` selector
returning a string rather than a `zip-loc` as expected. I have also added
a test assertion which checks for the expected functionality.

## Problem Description

When using the `find-in-text` selector in the last position of a `child`
selector no result will be found. Expected behavior is restored when you
wrap `find-in-text` with the `and` selector. Here is an example of the
problem:

```clojure
(require '[hickory.core :as h]
         '[hickory.select :as s])

(def html "<div><span>Apocalypse</span></div>")

(def htree (-> html
               h/parse
               h/as-hickory))

(s/select
 (s/child (s/tag :div)
          (s/find-in-text #"Apocalypse"))
 htree)
;; Expected Result => [{:type :element
;;                      :attrs nil
;;                      :tag :span
;;                      :content ["Apocalypse"]}]
;; Actual Result   => []

(s/select
 (s/child (s/tag :div)
          ;; Wrapping `find-in-text` in `and`
          (s/and (s/find-in-text #"Apocalypse")))
 htree)
;; We get the expected result:
;; => [{:type :element
;;      :attrs nil
;;      :tag :span
;;      :content ["Apocalypse"]}]
```

## Solution

The current version of `find-in-text` is supposed to return a function that takes
a zip-loc and returns a zip-loc if the node contains a text block matching a
provided regular expression. The current body of the function is as follows (minor
readability changes):

```clojure
(defn find-in-text
  [re]
  (fn [hzip-loc]
    (some #(re-find re %)
          (->> (zip/node hzip-loc)
               :content
               (filter string?)))))
```

The issue is in the return value of the returned function. Running
`(some #(re-find re %) ...)` will return the **first string** matching the regex
**rather than the zip-loc**. For example:

```clojure
(some #(re-find #"Luke" %)
      ["Matthew" "Mark" "Luke" "John"])
;; => "Luke"
```

The solution was quite simple: instead of returning the result of `(some ...)` we
check whether the result returned anything and if it did we then can return the
provided zip-loc. The result is as follows:

```clojure
(defn find-in-text
  [re]
  (fn [hzip-loc]
    (when (some #(re-find re %)
                (->> (zip/node hzip-loc)
                     :content
                     (filter string?)))
      hzip-loc)))
```
