### PR TITLE
properly deal with reflection warning

### DIFF
--- a/src/clj/hickory/core.clj
+++ b/src/clj/hickory/core.clj
@@ -144,16 +144,18 @@
     ([this] (trampoline as-hickory this (hzip/hickory-zip this)))
     ([this loc] (end-or-recur as-hickory loc (.getWholeText this)))))
 
-;; Jsoup/parse is polymorphic, we'll let reflection handle it for now
-(set! *warn-on-reflection* false)
-
 (defn parse
   "Parse an entire HTML document into a DOM structure that can be
    used as input to as-hiccup or as-hickory."
   [s]
-  (Jsoup/parse s))
-
-(set! *warn-on-reflection* true)
+  (cond (instance? String s)
+        (Jsoup/parse ^String s)
+        (instance? java.io.File s)
+        (Jsoup/parse ^java.io.File s)
+        (instance? java.nio.file.Path s)
+        (Jsoup/parse ^java.nio.file.Path s)
+        :else
+        (throw (ex-info "Invalid input for parse" {:type (type s)}))))
 
 (defn parse-fragment
   "Parse an HTML fragment (some group of tags that might be at home somewhere


### PR DESCRIPTION
Followup to PR https://github.com/clj-commons/hickory/pull/92/files

Function `hickory.core/parse` calls `Jsoup.parse` unary method. In current JSoup version `1.20.1` it is [overloaded](https://www.javadoc.io/doc/org.jsoup/jsoup/latest/org/jsoup/Jsoup.html#parse(java.io.File)) for `File`, `String` and `Path` classes.

Current implementation uses reflection to dispatch to the correct overloaded method implementation. However, proper approach would be dispatching based on type, and I took inspiration from https://github.com/dakrone/clj-http/pull/650 for this change.

